### PR TITLE
fix: fixed bulk get missing doc incorrect result

### DIFF
--- a/foodb/CHANGELOG.md
+++ b/foodb/CHANGELOG.md
@@ -4,7 +4,7 @@
 * (add) lock when generate view
 * (add) implement purge for couchdb
 * (fix) clearView will remove all related view
-* (fix) keyValue put local Doc will target correct table
+* (fix) keyValue delete local Doc will target correct table
 * (fix) replicate will throw exception instead of sync from begining when network error on getting local doc 
 * (fix) index selection when operator has _id
 * 

--- a/foodb/lib/src/key_value/key_value_get.dart
+++ b/foodb/lib/src/key_value/key_value_get.dart
@@ -62,26 +62,29 @@ mixin _KeyValueGet on _AbstractKeyValue {
                 rev: d.rev?.toString() ?? 'undefined',
                 error: 'not_found',
                 reason: 'missing'));
-      }
-      var result = DocHistory.fromJson(entry!.value);
-      var targetRev = d.rev ?? result.winnerWithDeleted!.rev;
-      var resultDoc = result.toDoc(
-        targetRev,
-        fromJsonT,
-        showRevision: revs,
-        showRevInfo: false,
-        showConflicts: false,
-        revLimit: _revLimit,
-      );
-      if (resultDoc != null) {
-        doc = BulkGetDoc(doc: resultDoc);
       } else {
-        doc = BulkGetDoc(
+        var result = DocHistory.fromJson(entry.value);
+        var targetRev = d.rev ?? result.winnerWithDeleted!.rev;
+        var resultDoc = result.toDoc(
+          targetRev,
+          fromJsonT,
+          showRevision: revs,
+          showRevInfo: false,
+          showConflicts: false,
+          revLimit: _revLimit,
+        );
+        if (resultDoc != null) {
+          doc = BulkGetDoc(doc: resultDoc);
+        } else {
+          doc = BulkGetDoc(
             error: BulkGetDocError(
-                id: d.id,
-                rev: d.rev?.toString() ?? 'undefined',
-                error: 'not_found',
-                reason: 'missing'));
+              id: d.id,
+              rev: d.rev?.toString() ?? 'undefined',
+              error: 'not_found',
+              reason: 'missing',
+            ),
+          );
+        }
       }
       results.add(BulkGetIdDocs(id: d.id, docs: [doc]));
     }

--- a/foodb_test/lib/src/test/get_test.dart
+++ b/foodb_test/lib/src/test/get_test.dart
@@ -106,11 +106,12 @@ List<Function(FoodbTestContext)> getTest() {
               BulkGetRequestDoc(
                   id: 'test-bulkget-missing-child', rev: Rev.fromString('2-c')),
               BulkGetRequestDoc(id: 'test-bulkget-no-rev'),
-              BulkGetRequestDoc(id: 'test-bulkget-deleted')
+              BulkGetRequestDoc(id: 'test-bulkget-deleted'),
+              BulkGetRequestDoc(id: 'test-bulkget-not-found')
             ]),
             fromJsonT: (json) => json,
             revs: true);
-        expect(response.results.length, 8);
+        expect(response.results.length, 9);
         expect(
             response.results.where((element) =>
                 element.docs.every((element) => element.doc != null)),
@@ -118,7 +119,7 @@ List<Function(FoodbTestContext)> getTest() {
         expect(
             response.results.where((element) => element.docs.every((element) =>
                 element.error?.reason.contains('missing') ?? false)),
-            hasLength(1));
+            hasLength(2));
       });
     },
     (FoodbTestContext ctx) {


### PR DESCRIPTION
bulk get missing doc should return object with missing status instead of throw exception

refer to couchdb bulk get sample response.
https://docs.couchdb.org/en/stable/api/database/bulk-api.html#db-bulk-get