### PR TITLE
fix: out of order with clusterChangeStream

### DIFF
--- a/foodb/lib/foodb.dart
+++ b/foodb/lib/foodb.dart
@@ -4,6 +4,7 @@ library foodb;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:isolate';
+import 'dart:collection';
 
 import 'package:crypto/crypto.dart' as crypto;
 import 'package:foodb/key_value_adapter.dart';
@@ -326,6 +327,9 @@ abstract class _AbstractKeyValue extends Foodb {
       localChangeStreamController = StreamController.broadcast();
   StreamController<MapEntry<SequenceKey, UpdateSequence>>
       clusterChangeStreamController = StreamController.broadcast();
+  final SplayTreeMap<int, MapEntry<SequenceKey, UpdateSequence>>
+      _pendingClusterChanges = SplayTreeMap();
+  int _lastClusterSeq = 0;
 
   @override
   String get dbUri => '${this.keyValueDb.type}://${this.dbName}';
@@ -378,16 +382,31 @@ abstract class _AbstractKeyValue extends Foodb {
       isLeader: isolateLeader,
     );
     localChangeStreamController.stream.listen((data) {
-      clusterChangeStreamController.sink.add(data);
+      _handleIncomingChange(data);
     });
     receiveFromIsolateMember.listen((data) {
       if (data is KeyvalueFoodbIsolateRef) {
         addIsolateMembership(data);
       }
       if (data is MapEntry<SequenceKey, UpdateSequence>) {
-        clusterChangeStreamController.sink.add(data);
+        _handleIncomingChange(data);
       }
     });
+  }
+
+  void _handleIncomingChange(MapEntry<SequenceKey, UpdateSequence> entry) {
+    _pendingClusterChanges[entry.key.key!] = entry;
+    _flushClusterChanges();
+  }
+
+  void _flushClusterChanges() {
+    while (_pendingClusterChanges.isNotEmpty &&
+        _pendingClusterChanges.firstKey() == _lastClusterSeq + 1) {
+      final next =
+          _pendingClusterChanges.remove(_pendingClusterChanges.firstKey())!;
+      _lastClusterSeq = next.key.key!;
+      clusterChangeStreamController.sink.add(next);
+    }
   }
 
   String encodeSeq(int seq) {

--- a/foodb/lib/src/key_value/key_value_util.dart
+++ b/foodb/lib/src/key_value/key_value_util.dart
@@ -44,6 +44,8 @@ mixin _KeyValueUtil on _AbstractKeyValue {
     await keyValueDb.initDb();
     var map = await keyValueDb.get(UtilsKey(key: '_revs_limit'));
     _revLimit = map?.value['_revs_limit'] ?? 1000;
+    _lastClusterSeq =
+        (await keyValueDb.last(SequenceKey(key: 0)))?.key?.key ?? 0;
     return true;
   }
 

--- a/foodb_objectbox_adapter/test/foodb_objectbox_adapter_isolate_test.dart
+++ b/foodb_objectbox_adapter/test/foodb_objectbox_adapter_isolate_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:isolate';
+import 'dart:math';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:foodb/foodb.dart';
@@ -122,7 +123,6 @@ void main() {
           // print('$docId - put done');
           final allDocs = await foodb.allDocs(GetViewRequest(), (t) => t);
           print(allDocs.rows.length);
-          ;
         }
       }, debugName: 'isolate $i');
     }
@@ -130,5 +130,80 @@ void main() {
     await Future.delayed(Duration(seconds: 20));
     var allDocs = await mainFoodb.allDocs(GetViewRequest(), (t) => t);
     expect(allDocs.rows.length, 2500);
+  });
+
+  // Test to validate issue https://github.com/feedmepos/foodb/issues/31
+  // To reproduce the issue, replace the _flushClusterChanges to clusterChangeStreamController.sink.add;
+  test('test-isolate-out-of-order-changes-stream', () async {
+    final dbName = 'test-isolate-out-of-order-changes-stream';
+    final mainAdapter = await getAdapter(dbName);
+    await Future.delayed(Duration(seconds: 1));
+    final mainFoodb = Foodb.keyvalue(
+      dbName: dbName,
+      keyValueDb: mainAdapter,
+      isolateLeader: true,
+    ) as KeyvalueFoodb;
+    final reference = mainFoodb.isolateReference;
+    for (var i = 0; i < 30; ++i) {
+      final isolateName = 'isolate-$i';
+      print('starting isolate $i');
+      await Future.delayed(Duration(milliseconds: 20));
+      Isolate.run(() async {
+        // print('start $isolateName');
+        final adapter = await getAdapter(dbName);
+        final foodb = Foodb.keyvalue(dbName: dbName, keyValueDb: adapter)
+            as KeyvalueFoodb;
+        foodb.addIsolateMembership(reference);
+        List<ChangeResult> results = [];
+        foodb.changesStream(ChangeRequest(feed: ChangeFeed.continuous),
+            onResult: (r) => results.add(r));
+        // wait until the main stream is listening
+        await Future.delayed(Duration(seconds: 1));
+        for (var docIndex = 0; docIndex < 300; ++docIndex) {
+          final docId = '$isolateName-doc-$docIndex';
+          // print('$docId - put');
+          await foodb.put(doc: Doc(id: docId, model: {"a": 1}));
+          // print('$docId - put done');
+        }
+        await Future.delayed(Duration(seconds: 1));
+      }, debugName: 'isolate $i');
+    }
+    num seq = 1;
+    final allChangeReceive = Completer();
+    final expectChanges = expectAsync1((ChangeResult d) {
+      print('expecting seq: ${d.seq} - id: ${d.id}');
+      expect(
+        num.parse(d.seq!.split('-')[0]),
+        seq,
+      );
+      seq++;
+      if (seq == 10000) {
+        allChangeReceive.complete();
+      }
+    }, count: 10000);
+
+    await mainFoodb.changesStream(ChangeRequest(feed: ChangeFeed.continuous),
+        onResult: expectChanges);
+    for (var docIndex = 0; docIndex < 1000; ++docIndex) {
+      final docId = 'main-doc-$docIndex';
+      // print('$docId - put');
+      await mainFoodb.put(doc: Doc(id: docId, model: {"a": 1}));
+      // print('$docId - put done');
+    }
+
+    await allChangeReceive.future;
+
+    final allSequences = mainAdapter.read(SequenceKey(),
+        desc: false, inclusiveEnd: true, inclusiveStart: true);
+
+    var expectedSeq = 1;
+    for (final entry in allSequences.records.entries) {
+      final key = entry.key;
+      expect(
+        key.key!,
+        expectedSeq,
+      );
+      expectedSeq++;
+    }
   });
 }


### PR DESCRIPTION
This pull request introduces enhancements to the `foodb` library to handle out-of-order changes in cluster streams more effectively. The changes include implementing a mechanism to buffer and flush cluster changes in sequence, initializing the last cluster sequence from the database, and adding a new test to validate the behavior. Below is a breakdown of the most important changes:

### Cluster Change Handling Enhancements:
* [`foodb/lib/foodb.dart`](diffhunk://#diff-43f99dabe69ca5ca74a8563c1db0a6a20c5791f8ec949813ec27784b4c394714R330-R332): Added `_pendingClusterChanges` (a `SplayTreeMap`) and `_lastClusterSeq` to buffer and track out-of-order cluster changes. Introduced `_handleIncomingChange` and `_flushClusterChanges` methods to ensure changes are processed sequentially. [[1]](diffhunk://#diff-43f99dabe69ca5ca74a8563c1db0a6a20c5791f8ec949813ec27784b4c394714R330-R332) [[2]](diffhunk://#diff-43f99dabe69ca5ca74a8563c1db0a6a20c5791f8ec949813ec27784b4c394714L381-R411)

### Initialization Updates:
* [`foodb/lib/src/key_value/key_value_util.dart`](diffhunk://#diff-25f4385065c3481df153062559416a7e9ea33dea2088642528dd66c064b8d144R47-R48): Updated `_KeyValueUtil` mixin to initialize `_lastClusterSeq` from the database using the last sequence key.

### Testing for Out-of-Order Changes:
* [`foodb_objectbox_adapter/test/foodb_objectbox_adapter_isolate_test.dart`](diffhunk://#diff-41b1c3bea64b5312bdbea4df3e15b1f1e8e6891ff79627ea56a79937c076c8adR134-R208): Added a new test, `test-isolate-out-of-order-changes-stream`, to validate the handling of out-of-order changes and ensure sequential processing of cluster changes.

### Minor Updates:
* [`foodb/lib/foodb.dart`](diffhunk://#diff-43f99dabe69ca5ca74a8563c1db0a6a20c5791f8ec949813ec27784b4c394714R7): Imported `dart:collection` for `SplayTreeMap`.
* [`foodb_objectbox_adapter/test/foodb_objectbox_adapter_isolate_test.dart`](diffhunk://#diff-41b1c3bea64b5312bdbea4df3e15b1f1e8e6891ff79627ea56a79937c076c8adR3): Imported `dart:math` and removed an unnecessary semicolon from the test file. [[1]](diffhunk://#diff-41b1c3bea64b5312bdbea4df3e15b1f1e8e6891ff79627ea56a79937c076c8adR3) [[2]](diffhunk://#diff-41b1c3bea64b5312bdbea4df3e15b1f1e8e6891ff79627ea56a79937c076c8adL125)